### PR TITLE
add space before revision (git hash) in email subject

### DIFF
--- a/bin/commit-email.rb
+++ b/bin/commit-email.rb
@@ -356,7 +356,7 @@ def make_subject(name, info)
   branches = info.branches
   subject = ""
   subject << "#{info.author}:"
-  subject << "#{info.revision}"
+  subject << " #{info.revision}"
   subject << " (#{branches.join(', ')})" unless branches.empty?
   subject << ": "
   subject << info.log.lstrip.lines.first.to_s.strip


### PR DESCRIPTION
This makes the email subject more readable.

Example before:
[ruby-cvs:74911] Nobuyoshi Nakada:429fdf3de2 (trunk): Added ChangeLog ...

Example after:
[ruby-cvs:74911] Nobuyoshi Nakada: 429fdf3de2 (trunk): Added ChangeLog ...

It is customary to have a space after a colon in most contexts in English. It's also confusing to have given name and family name separated by a space, but the hash glued to the family name.