### PR TITLE
Drop RSS support of commit-email

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,4 @@ script:
       -r https://svn.ruby-lang.org/repos/ruby \
       --rss-path /tmp/ruby.rdf \
       --rss-uri https://svn.ruby-lang.org/rss/ruby.rdf \
-      --error-to cvs-admin@ruby-lang.org \
-      --vcs git
+      --error-to cvs-admin@ruby-lang.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,5 @@ script:
     cd ./ruby &&
     ../bin/commit-email.rb ./ cvs-admin@ruby-lang.org \
       $(git rev-parse HEAD^) $(git rev-parse HEAD) refs/heads/trunk \
-      --name Ruby \
       --viewer-uri "https://git.ruby-lang.org/ruby.git/commit/?id=" \
-      -r https://svn.ruby-lang.org/repos/ruby \
-      --rss-path /tmp/ruby.rdf \
-      --rss-uri https://svn.ruby-lang.org/rss/ruby.rdf \
       --error-to cvs-admin@ruby-lang.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ script:
     cd ./ruby &&
     ../bin/commit-email.rb ./ cvs-admin@ruby-lang.org \
       $(git rev-parse HEAD^) $(git rev-parse HEAD) refs/heads/trunk \
-      -I ./lib \
       --name Ruby \
       --viewer-uri "https://git.ruby-lang.org/ruby.git/commit/?id=" \
       -r https://svn.ruby-lang.org/repos/ruby \

--- a/bin/commit-email.rb
+++ b/bin/commit-email.rb
@@ -153,7 +153,6 @@ class << CommitEmail
   def parse(args)
     options = OpenStruct.new
     options.error_to = []
-    options.from = nil
     options.repository_uri = nil
     options.rss_path = nil
     options.rss_uri = nil
@@ -166,11 +165,6 @@ class << CommitEmail
       opts.on('-e', '--error-to [TO]',
               'Add [TO] to to address when error is occurred') do |to|
         options.error_to << to unless to.nil?
-      end
-
-      opts.on('-f', '--from [FROM]',
-              'Use [FROM] as from address') do |from|
-        options.from = from
       end
 
       opts.on('--viewer-uri [URI]',
@@ -220,7 +214,7 @@ class << CommitEmail
     infos.each do |info|
       puts "#{info.branches.join(', ')}: #{info.revision} (#{info.author})"
 
-      from = options.from || info.author_email
+      from = info.author_email
       sendmail(to, from, make_mail(to, from, info, viewer_uri: options.viewer_uri))
 
       if options.repository_uri and
@@ -473,15 +467,9 @@ begin
 rescue StandardError => e
   $stderr.puts "#{e.class}: #{e.message}"
   $stderr.puts e.backtrace
-  from = ENV["USER"]
-  begin
-    _, options = CommitEmail.parse(rest)
-    from = options.from
-  rescue StandardError
-  end
-  CommitEmail.sendmail(to, from, <<-MAIL)
-From: #{from}
-To: #{to.join(', ')}
+  CommitEmail.sendmail(to, to, <<-MAIL)
+From: #{to}
+To: #{to}
 Subject: Error
 
 #{$!.class}: #{$!.message}

--- a/bin/commit-email.rb
+++ b/bin/commit-email.rb
@@ -357,7 +357,7 @@ class << CommitEmail
     headers << 'Content-Type: text/plain; charset=utf-8'
     headers << 'Content-Transfer-Encoding: quoted-printable'
     headers << "From: #{from}"
-    headers << "To: #{to.join(' ')}"
+    headers << "To: #{to}"
     headers << "Subject: #{make_subject(info)}"
     headers.find_all do |header|
       /\A\s*\z/ !~ header

--- a/bin/commit-email.rb
+++ b/bin/commit-email.rb
@@ -165,11 +165,6 @@ class << CommitEmail
     opts = OptionParser.new do |opts|
       opts.separator('')
 
-      opts.on('-I', '--include [PATH]',
-              'Add [PATH] to load path') do |path|
-        $LOAD_PATH.unshift(path)
-      end
-
       opts.on('-t', '--to [TO]',
               'Add [TO] to to address') do |to|
         options.to << to unless to.nil?

--- a/bin/commit-email.rb
+++ b/bin/commit-email.rb
@@ -152,7 +152,6 @@ class << CommitEmail
 
   def parse(args)
     options = OpenStruct.new
-    options.to = []
     options.error_to = []
     options.from = nil
     options.repository_uri = nil
@@ -163,11 +162,6 @@ class << CommitEmail
 
     opts = OptionParser.new do |opts|
       opts.separator('')
-
-      opts.on('-t', '--to [TO]',
-              'Add [TO] to to address') do |to|
-        options.to << to unless to.nil?
-      end
 
       opts.on('-e', '--error-to [TO]',
               'Add [TO] to to address when error is occurred') do |to|
@@ -223,7 +217,6 @@ class << CommitEmail
       end
     end
 
-    to = [to, *options.to]
     infos.each do |info|
       puts "#{info.branches.join(', ')}: #{info.revision} (#{info.author})"
 
@@ -248,7 +241,7 @@ class << CommitEmail
   end
 
   def sendmail(to, from, mail)
-    IO.popen([SENDMAIL, *to], 'w') do |f|
+    IO.popen([SENDMAIL, to], 'w') do |f|
       f.print(mail)
     end
   end
@@ -480,11 +473,9 @@ begin
 rescue StandardError => e
   $stderr.puts "#{e.class}: #{e.message}"
   $stderr.puts e.backtrace
-  to = [to]
   from = ENV["USER"]
   begin
     _, options = CommitEmail.parse(rest)
-    to = options.error_to unless options.error_to.empty?
     from = options.from
   rescue StandardError
   end

--- a/bin/commit-email.rb
+++ b/bin/commit-email.rb
@@ -152,11 +152,7 @@ class << CommitEmail
 
   def parse(args)
     options = OpenStruct.new
-    options.error_to = []
-    options.repository_uri = nil
-    options.rss_path = nil
-    options.rss_uri = nil
-    options.name = nil
+    options.error_to = nil
     options.viewvc_uri = nil
 
     opts = OptionParser.new do |opts|
@@ -164,32 +160,12 @@ class << CommitEmail
 
       opts.on('-e', '--error-to [TO]',
               'Add [TO] to to address when error is occurred') do |to|
-        options.error_to << to unless to.nil?
+        options.error_to = to
       end
 
       opts.on('--viewer-uri [URI]',
               'Use [URI] as URI of revision viewer') do |uri|
         options.viewer_uri = uri
-      end
-
-      opts.on('-r', '--repository-uri [URI]',
-              'Use [URI] as URI of repository') do |uri|
-        options.repository_uri = uri
-      end
-
-      opts.on('--rss-path [PATH]',
-              'Use [PATH] as output RSS path') do |path|
-        options.rss_path = path
-      end
-
-      opts.on("--rss-uri [URI]",
-              "Use [URI] as output RSS URI") do |uri|
-        options.rss_uri = uri
-      end
-
-      opts.on('--name [NAME]',
-              'Use [NAME] as repository name') do |name|
-        options.name = name
       end
 
       opts.on_tail('--help', 'Show this message') do
@@ -216,21 +192,6 @@ class << CommitEmail
 
       from = info.author_email
       sendmail(to, from, make_mail(to, from, info, viewer_uri: options.viewer_uri))
-
-      if options.repository_uri and
-          options.rss_path and
-          options.rss_uri
-        require 'rss/1.0'
-        require 'rss/dublincore'
-        require 'rss/content'
-        require 'rss/maker'
-        CommitEmail.extend(RSS::Utils)
-        output_rss(options.name,
-                   options.rss_path,
-                   options.rss_uri,
-                   options.repository_uri,
-                   info)
-      end
     end
   end
 
@@ -394,71 +355,6 @@ class << CommitEmail
   def make_mail(to, from, info, viewer_uri:)
     "#{make_header(to, from, info)}\n#{make_body(info, viewer_uri: viewer_uri)}"
   end
-
-  def output_rss(name, file, rss_uri, repos_uri, info)
-    prev_rss = nil
-    begin
-      if File.exist?(file)
-        File.open(file) do |f|
-          prev_rss = RSS::Parser.parse(f)
-        end
-      end
-    rescue RSS::Error
-    end
-
-    File.open(file, 'w') do |f|
-      f.print(make_rss(prev_rss, name, rss_uri, repos_uri, info).to_s)
-    end
-  end
-
-  def make_rss(base_rss, name, rss_uri, repos_uri, info)
-    RSS::Maker.make('1.0') do |maker|
-      maker.encoding = 'UTF-8'
-
-      maker.channel.about = rss_uri
-      maker.channel.title = rss_title(name || repos_uri)
-      maker.channel.link = repos_uri
-      maker.channel.description = rss_title(name || repos_uri)
-      maker.channel.dc_date = info.date
-
-      if base_rss
-        base_rss.items.each do |item|
-          item.setup_maker(maker)
-        end
-      end
-
-      diff_info(info, repos_uri).each do |name, infos|
-        infos.each do |desc, link|
-          item = maker.items.new_item
-          item.title = name
-          item.description = desc
-          item.content_encoded = "<pre>#{h(desc)}</pre>"
-          item.link = link
-          item.dc_date = info.date
-          item.dc_creator = info.author
-        end
-      end
-
-      maker.items.do_sort = true
-      maker.items.max_size = 15
-    end
-  end
-
-  def rss_title(name)
-    "Repository of #{name}"
-  end
-
-  def rss_items(items, info, repos_uri)
-    diff_info(info, repos_uri).each do |name, infos|
-      infos.each do |desc, link|
-        items << [link, name, desc, info.date]
-      end
-    end
-
-    items.sort_by do |uri, title, desc, date|
-      date
-    end.reverse
-  end
 end
 
 repo_path, to, *rest = ARGV
@@ -467,6 +363,9 @@ begin
 rescue StandardError => e
   $stderr.puts "#{e.class}: #{e.message}"
   $stderr.puts e.backtrace
+
+  _, options = CommitEmail.parse(rest)
+  to = options.error_to
   CommitEmail.sendmail(to, to, <<-MAIL)
 From: #{to}
 To: #{to}

--- a/hooks/post-receive-pre.sh
+++ b/hooks/post-receive-pre.sh
@@ -24,11 +24,7 @@ log "args: $*"
 # log "==> commit-email.rb"
 # "${ruby_commit_hook}/bin/commit-email.rb" \
 #    "$ruby_git" ruby-cvs@ruby-lang.org $* \
-#    --name Ruby \
 #    --viewer-uri "https://git.ruby-lang.org/ruby.git/commit/?id=" \
-#    -r https://svn.ruby-lang.org/repos/ruby \
-#    --rss-path /tmp/ruby.rdf \
-#    --rss-uri https://svn.ruby-lang.org/rss/ruby.rdf \
 #    --error-to cvs-admin@ruby-lang.org
 
 log "==> redmine fetch changesets"

--- a/hooks/post-receive-pre.sh
+++ b/hooks/post-receive-pre.sh
@@ -29,8 +29,7 @@ log "args: $*"
 #    -r https://svn.ruby-lang.org/repos/ruby \
 #    --rss-path /tmp/ruby.rdf \
 #    --rss-uri https://svn.ruby-lang.org/rss/ruby.rdf \
-#    --error-to cvs-admin@ruby-lang.org \
-#    --vcs git
+#    --error-to cvs-admin@ruby-lang.org
 
 log "==> redmine fetch changesets"
 curl -s "https://bugs.ruby-lang.org/sys/fetch_changesets?key=`cat ~git/config/redmine.key`" &

--- a/hooks/post-receive-pre.sh
+++ b/hooks/post-receive-pre.sh
@@ -24,7 +24,6 @@ log "args: $*"
 # log "==> commit-email.rb"
 # "${ruby_commit_hook}/bin/commit-email.rb" \
 #    "$ruby_git" ruby-cvs@ruby-lang.org $* \
-#    -I "${ruby_commit_hook}/lib" \
 #    --name Ruby \
 #    --viewer-uri "https://git.ruby-lang.org/ruby.git/commit/?id=" \
 #    -r https://svn.ruby-lang.org/repos/ruby \

--- a/hooks/post-receive.sh
+++ b/hooks/post-receive.sh
@@ -23,11 +23,7 @@ log "==> notify slack"
 log "==> commit-email.rb"
 "${ruby_commit_hook}/bin/commit-email.rb" \
    "$ruby_git" ruby-cvs@ruby-lang.org $* \
-   --name Ruby \
    --viewer-uri "https://git.ruby-lang.org/ruby.git/commit/?id=" \
-   -r https://svn.ruby-lang.org/repos/ruby \
-   --rss-path /tmp/ruby.rdf \
-   --rss-uri https://svn.ruby-lang.org/rss/ruby.rdf \
    --error-to cvs-admin@ruby-lang.org
 
 log "==> redmine fetch changesets"

--- a/hooks/post-receive.sh
+++ b/hooks/post-receive.sh
@@ -23,7 +23,6 @@ log "==> notify slack"
 log "==> commit-email.rb"
 "${ruby_commit_hook}/bin/commit-email.rb" \
    "$ruby_git" ruby-cvs@ruby-lang.org $* \
-   -I "${ruby_commit_hook}/lib" \
    --name Ruby \
    --viewer-uri "https://git.ruby-lang.org/ruby.git/commit/?id=" \
    -r https://svn.ruby-lang.org/repos/ruby \

--- a/hooks/post-receive.sh
+++ b/hooks/post-receive.sh
@@ -28,8 +28,7 @@ log "==> commit-email.rb"
    -r https://svn.ruby-lang.org/repos/ruby \
    --rss-path /tmp/ruby.rdf \
    --rss-uri https://svn.ruby-lang.org/rss/ruby.rdf \
-   --error-to cvs-admin@ruby-lang.org \
-   --vcs git
+   --error-to cvs-admin@ruby-lang.org
 
 log "==> redmine fetch changesets"
 curl -s "https://bugs.ruby-lang.org/sys/fetch_changesets?key=`cat ~git/config/redmine.key`" &


### PR DESCRIPTION
`/tmp/ruby.rdf` does not seem to have worked even before Git migration.

Let's just use https://github.com/ruby/ruby/commits/trunk.atom or https://git.ruby-lang.org/ruby.git/atom instead.