### PR TITLE
Add stable maintainers check in before commit hook.

### DIFF
--- a/bin/check-email-and-refname.rb
+++ b/bin/check-email-and-refname.rb
@@ -44,7 +44,7 @@ ARGV.each_slice(3) do |oldrev, newrev, refname|
   # `/var/git-svn/ruby` uses `remote.cgit.url=git@git.ruby-lang.org:ruby.git`.
   # ~git/.ssh/id_rsa.pub is registered as `SVN_ACCOUNT_NAME=git` in authorized_keys.
   unless PUSHABLE_REFNAMES.include?(refname) || svn_account_name == "git" || # git-svn
-         (is_pushable_stable_branch?(refname) && STABLE_BRANCH_MAINTAINERS.include?(svn_account_name) # stable maintainer
+         (is_pushable_stable_branch?(refname) && STABLE_BRANCH_MAINTAINERS.include?(svn_account_name)) # stable maintainer
     STDERR.puts "You pushed '#{newrev}' to '#{refname}', but you can push commits "\
       "to only '#{PUSHABLE_REFNAMES.join("', '")}'. (svn_account_name: #{svn_account_name})"
     exit 1

--- a/bin/check-email-and-refname.rb
+++ b/bin/check-email-and-refname.rb
@@ -11,11 +11,19 @@ ADMIN_USERS = [
   "hsbt",
   "naruse",
 ]
+STABLE_BRANCH_MAINTAINERS = [
+  "usa",
+  "nagachika",
+]
 PUSHABLE_REFNAMES = [
   "refs/heads/master",
   "refs/notes/commits",
   "refs/notes/log-fix",
 ]
+
+def is_pushable_stable_branch?(refname)
+  %r{\Arefs/heads/ruby_(\d+)_(\d+)\Z} =~ refname and (($1 == "2" and $2.to_i >= 7) or ($1.to_i >= 3))
+end
 
 SVN_TO_EMAILS = YAML.safe_load(File.read(File.expand_path('../config/email.yml', __dir__)))
 LOG_FILE = "/home/git/email.log"
@@ -35,7 +43,8 @@ emails = SVN_TO_EMAILS[svn_account_name]
 ARGV.each_slice(3) do |oldrev, newrev, refname|
   # `/var/git-svn/ruby` uses `remote.cgit.url=git@git.ruby-lang.org:ruby.git`.
   # ~git/.ssh/id_rsa.pub is registered as `SVN_ACCOUNT_NAME=git` in authorized_keys.
-  if !PUSHABLE_REFNAMES.include?(refname) && svn_account_name != "git" # git-svn
+  unless PUSHABLE_REFNAMES.include?(refname) || svn_account_name == "git" || # git-svn
+         (is_pushable_stable_branch?(refname) && STABLE_BRANCH_MAINTAINERS.include?(svn_account_name) # stable maintainer
     STDERR.puts "You pushed '#{newrev}' to '#{refname}', but you can push commits "\
       "to only '#{PUSHABLE_REFNAMES.join("', '")}'. (svn_account_name: #{svn_account_name})"
     exit 1


### PR DESCRIPTION
I've got the error message when I try to push to the ruby_2_7 branch.

```
remote: You pushed '16aef5da5622971ae83dcc281b03a53c5f622ca3' to 'refs/heads/ruby_2_7', but you can push commits to only 'refs/heads/master', 'refs/notes/commits', 'refs/notes/log-fix'. (svn_account_name: nagachika)
To git.ruby-lang.org:ruby.git
 ! [remote rejected]       ruby_2_7 -> ruby_2_7 (pre-receive hook declined)
```

I think the stable branch maintainers should be able to push to the stable branches newer than `ruby_2_6`. In this PR I added `STABLE_BRANCH_MAINTAINERS` role and allow them to push to the stable branches, which in the format `ruby_#_#`.