### PR TITLE
Use /data/ruby-commit-hook instead of /home/git

### DIFF
--- a/bin/update-default-gem.sh
+++ b/bin/update-default-gem.sh
@@ -14,7 +14,7 @@ gem_name="$1"
 before="$2"
 after="$3"
 ruby_repo="/var/git/ruby.git"
-ruby_workdir="/home/git/update-default-gem-${gem_name}"
+ruby_workdir="/data/ruby-commit-hook/update-default-gem-${gem_name}"
 log_path="/tmp/update-default-gem-${gem_name}.log"
 
 function log() {

--- a/bin/update-ruby.sh
+++ b/bin/update-ruby.sh
@@ -11,7 +11,7 @@ export LANG=en_US.UTF-8
 
 ruby_repo="/var/git/ruby.git"
 ruby_branch="$1"
-ruby_workdir="/home/git/update-ruby"
+ruby_workdir="/data/ruby-commit-hook/update-ruby"
 log_path="/tmp/update-ruby.log"
 
 function log() {


### PR DESCRIPTION
`/` without `/data` is too small on svn.ruby-lang.org. That is only 8GB.